### PR TITLE
Fix two typos in "Advising objects" example

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,7 +305,7 @@ var wakeAd1 = advise(ethel, "wakeUp", {
 var wakeAd2 = advise(ethel, "wakeUp", {
     before: function(){ console.log("brush my teeth"); }
 });
-var wakeAd2 = advise(ethel, "wakeUp", {
+var wakeAd3 = advise(ethel, "wakeUp", {
     before: function(){ console.log("dress up for work"); }
 });
 
@@ -332,7 +332,7 @@ ethel.sleep();
 // let's save on electricity
 wakeAd1.unadvise();
 // brushing teeth more than once a day is overrated, right?
-sleepAd1.unadvise();
+sleepAd2.unadvise();
 // no need to dress up for work either --- Ethel is CEO!
 wakeAd3.unadvise();
 


### PR DESCRIPTION
There were two minor typos in the variables names of one example in the readme. It's pretty clear from the context what was intended, however.
